### PR TITLE
remove unused import

### DIFF
--- a/src/ward_coverage/hook_impl.py
+++ b/src/ward_coverage/hook_impl.py
@@ -1,5 +1,4 @@
 import os
-from distutils.command.install_headers import install_headers
 from typing import Any, Dict, List, Union
 from unittest import mock
 


### PR DESCRIPTION
Remove unused import from distutils for the plugin to work in python version 3.12

Closes #4 